### PR TITLE
Feat/implement pokedex list

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,13 @@
 {
   "root": true,
-  "ignorePatterns": ["projects/**/*"],
+  "ignorePatterns": [
+    "projects/**/*"
+  ],
   "overrides": [
     {
-      "files": ["*.ts"],
+      "files": [
+        "*.ts"
+      ],
       "extends": [
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
@@ -16,7 +20,7 @@
           "error",
           {
             "type": "attribute",
-            "prefix": "app",
+            "prefix": "pkm",
             "style": "camelCase"
           }
         ],
@@ -24,24 +28,47 @@
           "error",
           {
             "type": "element",
-            "prefix": "app",
+            "prefix": "pkm",
             "style": "kebab-case"
           }
         ]
       }
     },
     {
-      "files": ["*.html"],
-      "extends": ["plugin:@angular-eslint/template/recommended"],
+      "files": [
+        "*.html"
+      ],
+      "extends": [
+        "plugin:@angular-eslint/template/recommended"
+      ],
       "rules": {}
     },
     {
-      "files": ["*.html"],
-      "excludedFiles": ["*inline-template-*.component.html"],
-      "extends": ["plugin:prettier/recommended"],
+      "files": [
+        "*.html"
+      ],
+      "excludedFiles": [
+        "*inline-template-*.component.html"
+      ],
+      "extends": [
+        "plugin:prettier/recommended"
+      ],
       "rules": {
-        "prettier/prettier": ["error", { "parser": "angular" }]
+        "prettier/prettier": [
+          "error",
+          {
+            "parser": "angular"
+          }
+        ]
       }
+    },
+    {
+      "files": [
+        "*.ts"
+      ],
+      "extends": [
+        "plugin:@ngrx/strict-requiring-type-checking"
+      ]
     }
   ]
 }

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   test:
+    name: Build, tests and lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,8 +33,11 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Build
+        run: npm run build
+
       - name: Run linter and prettier
         run: npm run lint
 
       - name: Run tests with coverage
-        run: npm run test:cov
+        run: npm run test:ci

--- a/angular.json
+++ b/angular.json
@@ -12,7 +12,7 @@
       },
       "root": "",
       "sourceRoot": "src",
-      "prefix": "app",
+      "prefix": "pkm",
       "architect": {
         "build": {
           "builder": "@angular-devkit/build-angular:browser",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,9 @@
         "@angular/platform-browser": "^15.2.0",
         "@angular/platform-browser-dynamic": "^15.2.0",
         "@angular/router": "^15.2.0",
+        "@ngrx/effects": "^15.4.0",
+        "@ngrx/entity": "^15.4.0",
+        "@ngrx/store": "^15.4.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.12.0"
@@ -30,6 +33,7 @@
         "@angular-eslint/template-parser": "15.2.1",
         "@angular/cli": "~15.2.7",
         "@angular/compiler-cli": "^15.2.0",
+        "@ngrx/eslint-plugin": "^15.4.0",
         "@types/jest": "^28.0.0",
         "@typescript-eslint/eslint-plugin": "5.48.2",
         "@typescript-eslint/parser": "5.48.2",
@@ -3941,6 +3945,60 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
+    "node_modules/@ngrx/effects": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/effects/-/effects-15.4.0.tgz",
+      "integrity": "sha512-/8gHhOM9aeGaw8OG2LLwi4I4p84xzG0EU9TqWrvQcW74wn8sFZONjLvUte5YOzJ5502PPFFrfXSOc+lHnVAJUA==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^15.0.0",
+        "@ngrx/store": "15.4.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
+      }
+    },
+    "node_modules/@ngrx/entity": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/entity/-/entity-15.4.0.tgz",
+      "integrity": "sha512-DmfbbasV5bth9APAiwH9ovDwJ/rtEUm4pJvTd6Eds/kOJ6Ime9MZwEhtglXlk2jMwe7f08pl1jzFhYIjI277aQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^15.0.0",
+        "@ngrx/store": "15.4.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
+      }
+    },
+    "node_modules/@ngrx/eslint-plugin": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/eslint-plugin/-/eslint-plugin-15.4.0.tgz",
+      "integrity": "sha512-o7dJMuJidETXkgPUd137ujGGHFz2xDhZt52bCTQyVaG8wF7gyUqhzDRVLtayUdiwUsdQ1z14SKHbQ1QDYung7g==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.4.0",
+        "eslint-etc": "^5.1.0",
+        "semver": "^7.3.5",
+        "strip-json-comments": "3.1.1"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.0.0",
+        "typescript": ">=4.4.0"
+      }
+    },
+    "node_modules/@ngrx/store": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/store/-/store-15.4.0.tgz",
+      "integrity": "sha512-OvCuNBHL8mAUnRTS6QSFm+IunspsYNu2cCwDovBNn7EGhxRuGihBeNoX47jCqWPHBFtokj4BlatDfpJ/yCh4xQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "^15.0.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
+      }
+    },
     "node_modules/@ngtools/webpack": {
       "version": "15.2.7",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-15.2.7.tgz",
@@ -4645,6 +4703,154 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.59.1.tgz",
+      "integrity": "sha512-KVtKcHEizCIRx//LC9tBi6xp94ULKbU5StVHBVWURJQOVa2qw6HP28Hu7LmHrQM3p9I3q5Y2VR4wKllCJ3IWrw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "5.59.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.1.tgz",
+      "integrity": "sha512-mau0waO5frJctPuAzcxiNWqJR5Z8V0190FTSqRw1Q4Euop6+zTwHAf8YIXNwDOT29tyUDrQ65jSg9aTU/H0omA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/visitor-keys": "5.59.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/types": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.1.tgz",
+      "integrity": "sha512-dg0ICB+RZwHlysIy/Dh1SP+gnXNzwd/KS0JprD3Lmgmdq+dJAJnUPe1gNG34p0U19HvRlGX733d/KqscrGC1Pg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.1.tgz",
+      "integrity": "sha512-lYLBBOCsFltFy7XVqzX0Ju+Lh3WPIAWxYpmH/Q7ZoqzbscLiCW00LeYCdsUnnfnj29/s1WovXKh2gwCoinHNGA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/visitor-keys": "5.59.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/utils": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.1.tgz",
+      "integrity": "sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.59.1",
+        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/typescript-estree": "5.59.1",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.1.tgz",
+      "integrity": "sha512-6waEYwBTCWryx0VJmP7JaM4FpipLsFl9CvYf2foAE8Qh/Y0s+bxWysciwOs0LTBED4JCaNxTZ5rGadB14M6dwA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -7443,6 +7649,21 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-etc": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-etc/-/eslint-etc-5.2.1.tgz",
+      "integrity": "sha512-lFJBSiIURdqQKq9xJhvSJFyPA+VeTh5xvk24e8pxVL7bwLBtGF60C/KRkLTMrvCZ6DA3kbPuYhLWY0TZMlqTsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.0.0",
+        "tsutils": "^3.17.1",
+        "tsutils-etc": "^1.4.1"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0",
+        "typescript": ">=4.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -16557,6 +16778,24 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils-etc": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tsutils-etc/-/tsutils-etc-1.4.2.tgz",
+      "integrity": "sha512-2Dn5SxTDOu6YWDNKcx1xu2YUy6PUeKrWZB/x2cQ8vY2+iz3JRembKn/iZ0JLT1ZudGNwQQvtFX9AwvRHbXuPUg==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs": "^17.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "ts-flags": "bin/ts-flags",
+        "ts-kind": "bin/ts-kind"
+      },
+      "peerDependencies": {
+        "tsutils": "^3.0.0",
+        "typescript": ">=4.0.0"
       }
     },
     "node_modules/tsutils/node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "@angular/platform-browser": "^15.2.0",
     "@angular/platform-browser-dynamic": "^15.2.0",
     "@angular/router": "^15.2.0",
+    "@ngrx/effects": "^15.4.0",
+    "@ngrx/entity": "^15.4.0",
+    "@ngrx/store": "^15.4.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.12.0"
@@ -36,6 +39,7 @@
     "@angular-eslint/template-parser": "15.2.1",
     "@angular/cli": "~15.2.7",
     "@angular/compiler-cli": "^15.2.0",
+    "@ngrx/eslint-plugin": "^15.4.0",
     "@types/jest": "^28.0.0",
     "@typescript-eslint/eslint-plugin": "5.48.2",
     "@typescript-eslint/parser": "5.48.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "test:cov": "ng test --coverage",
+    "test:ci": "ng test --watch=false --coverage",
     "lint": "ng lint",
     "lint:fix": "ng lint --fix"
   },

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,8 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { PokedexComponent } from './pokedex/pokedex.component';
 
-const routes: Routes = [];
+const routes: Routes = [{ path: '', component: PokedexComponent }];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,7 @@
-<style></style>
+<header class="app__header">
+  <h1 class="app__header__title">Pokedex</h1>
+</header>
 
-<div class="pokedex">Hello world!</div>
-
-<router-outlet></router-outlet>
+<div class="app__container">
+  <router-outlet></router-outlet>
+</div>

--- a/src/app/app.component.sass
+++ b/src/app/app.component.sass
@@ -1,3 +1,12 @@
-.pokedex {
-  background-color: #e3e3e3;
-}
+.app
+
+  &__header
+    background-color: #ef5350
+
+    &__title
+      margin: auto
+      max-width: 65rem
+
+  &__container
+    margin: auto
+    max-width: 65rem

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -16,18 +16,12 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'test-pokemon-api'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('test-pokemon-api');
-  });
-
-  it('should render title', () => {
+  it('should render header', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('.pokedex')?.textContent).toContain(
-      'Hello world!'
-    );
+    expect(
+      compiled.querySelector('.app__header__title')?.textContent
+    ).toContain('Pokedex');
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,8 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'app-root',
+  selector: 'pkm-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.sass'],
 })
-export class AppComponent {
-  title = 'test-pokemon-api';
-}
+export class AppComponent {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,13 +1,27 @@
 import { NgModule } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
 import { BrowserModule } from '@angular/platform-browser';
+import { EffectsModule } from '@ngrx/effects';
+import { StoreModule } from '@ngrx/store';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { PokemonService } from './services/pokemon.service';
+import { PokemonEffects } from './store/pokemon-store/effects';
+import { pokemonReducer } from './store/pokemon-store/reducer';
+import { PokedexModule } from './pokedex/pokedex.module';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, AppRoutingModule],
-  providers: [],
+  imports: [
+    AppRoutingModule,
+    BrowserModule,
+    EffectsModule.forRoot(PokemonEffects),
+    HttpClientModule,
+    StoreModule.forRoot({ pokemons: pokemonReducer }),
+    PokedexModule,
+  ],
+  providers: [PokemonService],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/definitions/pokemon.ts
+++ b/src/app/definitions/pokemon.ts
@@ -1,0 +1,23 @@
+export interface PokemonLink {
+  name: string;
+  url: string;
+}
+
+export interface Pokemon {
+  id: number;
+  name: string;
+  sprites: {
+    front_default: string;
+  };
+  types: {
+    slot: number;
+    type: {
+      name: string;
+    };
+  }[];
+}
+
+export interface PaginatedAnswer<T> {
+  count: number;
+  results: T[];
+}

--- a/src/app/pokedex/pipes/pokemon-number.pipe.spec.ts
+++ b/src/app/pokedex/pipes/pokemon-number.pipe.spec.ts
@@ -1,0 +1,21 @@
+import { PokemonNumberPipe } from './pokemon-number.pipe';
+
+describe('pokemonNumber Pipe', () => {
+  let pokemonNumberPipe: PokemonNumberPipe;
+
+  beforeAll(() => {
+    pokemonNumberPipe = new PokemonNumberPipe();
+  });
+
+  it('should add leading 0 and return the number formatted', () => {
+    const result = pokemonNumberPipe.transform(2);
+
+    expect(result).toBe('#0002');
+  });
+
+  it(`should only add the leading '#' when the number is big enough`, () => {
+    const result = pokemonNumberPipe.transform(1234);
+
+    expect(result).toBe('#1234');
+  });
+});

--- a/src/app/pokedex/pipes/pokemon-number.pipe.ts
+++ b/src/app/pokedex/pipes/pokemon-number.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/*
+ * Format a number to display a number in the '#0000' format
+ *
+ * Usage:
+ *   value | pokemonNumber
+ * Example:
+ *   {{ 2 | pokemonNumber }}
+ *   formats to: #0002
+ */
+@Pipe({ name: 'pokemonNumber' })
+export class PokemonNumberPipe implements PipeTransform {
+  transform(value: number): string {
+    const paddedNumber = `${value}`.padStart(4, '0');
+    return `#${paddedNumber}`;
+  }
+}

--- a/src/app/pokedex/pokedex.component.html
+++ b/src/app/pokedex/pokedex.component.html
@@ -1,0 +1,20 @@
+<div class="pokedex__container">
+  <div
+    *ngIf="error$ | async as error"
+    class="pokedex__container__item pokedex__container--error">
+    An error occured, we cannot display pokemons right now. Please try again
+    later. Details: {{ error }}
+  </div>
+
+  <div class="pokedex__container__items">
+    <pkm-pokemon-tile
+      *ngFor="let pokemon of pokemons$ | async"
+      [pokemon]="pokemon" />
+  </div>
+
+  <div
+    *ngIf="isLoading$ | async"
+    class="pokedex__container__item pokedex__container--loading">
+    Loading pokemons, please wait...
+  </div>
+</div>

--- a/src/app/pokedex/pokedex.component.sass
+++ b/src/app/pokedex/pokedex.component.sass
@@ -1,0 +1,8 @@
+.pokedex
+
+  &__container__items
+    margin: 1.5rem 0
+    display: flex
+    flex-wrap: wrap
+    flex-direction: row
+    justify-content: center

--- a/src/app/pokedex/pokedex.component.spec.ts
+++ b/src/app/pokedex/pokedex.component.spec.ts
@@ -1,0 +1,93 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+
+import { PokedexComponent } from './pokedex.component';
+import {
+  initialPokemonState,
+  PokemonState,
+} from '../store/pokemon-store/pokemonState';
+import { Pokemon } from '../definitions/pokemon';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+
+describe('PokedexComponent', () => {
+  let store: MockStore<{ pokemons: PokemonState }>;
+  const initialState = { pokemons: initialPokemonState };
+
+  let component: PokedexComponent;
+  let fixture: ComponentFixture<PokedexComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PokedexComponent],
+      providers: [provideMockStore({ initialState })],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PokedexComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    store = TestBed.inject(MockStore);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the loading message when the loading state is true', () => {
+    store.setState({
+      pokemons: {
+        ...initialPokemonState,
+        isLoading: true,
+      },
+    });
+
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(
+      compiled.querySelector('.pokedex__container--loading')?.textContent
+    ).toContain('Loading pokemons, please wait...');
+  });
+
+  it('should display the error section in case of error', () => {
+    store.setState({
+      pokemons: {
+        ...initialPokemonState,
+        error: 'Something went wrong',
+      },
+    });
+
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    const loadingContent = compiled.querySelector(
+      '.pokedex__container--loading'
+    );
+    const errorContent = compiled.querySelector('.pokedex__container--error');
+
+    expect(loadingContent).toBeNull();
+    expect(errorContent?.textContent).toContain(
+      `An error occured, we cannot display pokemons right now. Please try again later. Details: Something went wrong`
+    );
+  });
+
+  it('should display the list of pokemons when it is loaded', () => {
+    store.setState({
+      pokemons: {
+        ...initialPokemonState,
+        items: [{} as Pokemon, {} as Pokemon],
+      },
+    });
+
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    const loadingContent = compiled.querySelector(
+      '.pokedex__container--loading'
+    );
+    const errorContent = compiled.querySelector('.pokedex__container--error');
+    const listContent = compiled.querySelector('.pokedex__container__items');
+
+    expect(loadingContent).toBeNull();
+    expect(errorContent).toBeNull();
+    expect(listContent?.children).toHaveLength(2);
+  });
+});

--- a/src/app/pokedex/pokedex.component.ts
+++ b/src/app/pokedex/pokedex.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
+
+import { Pokemon } from '../definitions/pokemon';
+import { loadRequest } from '../store/pokemon-store/actions';
+import {
+  selectError,
+  selectLoadingState,
+  selectPokemons,
+} from '../store/pokemon-store/selector';
+
+@Component({
+  selector: 'pkm-pokedex',
+  templateUrl: './pokedex.component.html',
+  styleUrls: ['./pokedex.component.sass'],
+})
+export class PokedexComponent implements OnInit {
+  pokemons$: Observable<Pokemon[]>;
+  isLoading$: Observable<boolean>;
+  error$: Observable<string | null>;
+
+  constructor(private store: Store) {
+    this.pokemons$ = this.store.select(selectPokemons);
+    this.isLoading$ = this.store.select(selectLoadingState);
+    this.error$ = this.store.select(selectError);
+  }
+
+  ngOnInit() {
+    this.store.dispatch(loadRequest({ page: 0 }));
+  }
+}

--- a/src/app/pokedex/pokedex.module.ts
+++ b/src/app/pokedex/pokedex.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PokedexComponent } from './pokedex.component';
+import { PokemonTileComponent } from './pokemon-tile.component';
+import { PokemonNumberPipe } from './pipes/pokemon-number.pipe';
+
+@NgModule({
+  declarations: [PokedexComponent, PokemonTileComponent, PokemonNumberPipe],
+  imports: [CommonModule],
+})
+export class PokedexModule {}

--- a/src/app/pokedex/pokemon-tile.component.html
+++ b/src/app/pokedex/pokemon-tile.component.html
@@ -1,0 +1,14 @@
+<div class="pokemon">
+  <img
+    src="{{ pokemon.sprites.front_default }}"
+    alt=""
+    class="pokemon__sprite" />
+  <p class="pokemon__number">{{ pokemon.id | pokemonNumber }}</p>
+
+  <h2 class="pokemon__name">{{ pokemon.name }}</h2>
+  <ul class="pokemon__types">
+    <li class="pokemon__types__type" *ngFor="let t of pokemon.types">
+      {{ t.type.name }}
+    </li>
+  </ul>
+</div>

--- a/src/app/pokedex/pokemon-tile.component.sass
+++ b/src/app/pokedex/pokemon-tile.component.sass
@@ -1,0 +1,40 @@
+.pokemon
+  width: 15rem
+  height: 18rem
+  padding-top: 1rem
+  margin: .5rem
+  display: flex
+  flex-direction: column
+  justify-content: start
+  border: 1px solid #ddd
+  border-radius: 5px
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1)
+  overflow: hidden
+
+  &__sprite
+    margin: 0 auto
+    width: 205px
+    height: 205px
+    background: #f3f3f3
+    border-radius: 5px
+
+  &__number
+    margin: 0
+    color: #919191
+    text-align: center
+
+  &__name
+    margin: 0
+    text-align: center
+
+  &__types
+    padding: 0
+    margin: 0
+    display: flex
+    flex-wrap: wrap
+    flex-direction: row
+    justify-content: center
+
+    &__type
+      margin: 2px
+      display: flex

--- a/src/app/pokedex/pokemon-tile.component.spec.ts
+++ b/src/app/pokedex/pokemon-tile.component.spec.ts
@@ -1,0 +1,57 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PokemonTileComponent } from './pokemon-tile.component';
+import { PokemonNumberPipe } from './pipes/pokemon-number.pipe';
+describe('PokemonTileComponent', () => {
+  let component: PokemonTileComponent;
+  let fixture: ComponentFixture<PokemonTileComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PokemonTileComponent, PokemonNumberPipe],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PokemonTileComponent);
+    component = fixture.componentInstance;
+    component.pokemon = {
+      id: 1,
+      name: 'test',
+      types: [
+        { type: { name: 'flying' }, slot: 1 },
+        { type: { name: 'dragon' }, slot: 2 },
+      ],
+      sprites: { front_default: 'img.url' },
+    };
+    fixture.detectChanges();
+  });
+
+  it('should display the image', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    const image = compiled.querySelector('.pokemon__sprite');
+    expect(image?.getAttribute('src')).toBe('img.url');
+  });
+
+  it('should display the pokemon number', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    const number = compiled.querySelector('.pokemon__number');
+    expect(number?.textContent).toBe('#0001');
+  });
+
+  it('should display the pokemon name', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    const name = compiled.querySelector('.pokemon__name');
+    expect(name?.textContent).toBe('test');
+  });
+
+  it('should display the pokemon types', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    const types = compiled.querySelector('.pokemon__types');
+    expect(types?.children).toHaveLength(2);
+    expect(types?.children[0].textContent).toContain('flying');
+    expect(types?.children[1].textContent).toContain('dragon');
+  });
+});

--- a/src/app/pokedex/pokemon-tile.component.ts
+++ b/src/app/pokedex/pokemon-tile.component.ts
@@ -1,0 +1,15 @@
+import { Attribute, Component, Input } from '@angular/core';
+import { Pokemon } from '../definitions/pokemon';
+
+@Component({
+  selector: 'pkm-pokemon-tile',
+  templateUrl: './pokemon-tile.component.html',
+  styleUrls: ['./pokemon-tile.component.sass'],
+})
+export class PokemonTileComponent {
+  @Input() pokemon: Pokemon;
+
+  constructor(@Attribute('pokemon') pokemon: Pokemon) {
+    this.pokemon = pokemon;
+  }
+}

--- a/src/app/services/pokemon.service.spec.ts
+++ b/src/app/services/pokemon.service.spec.ts
@@ -1,0 +1,58 @@
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { Pokemon, PokemonLink } from '../definitions/pokemon';
+import { PokemonService } from './pokemon.service';
+
+describe('PokemonService', () => {
+  let controller: HttpTestingController;
+  let service: PokemonService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PokemonService],
+    });
+
+    controller = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(PokemonService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getPokemons', () => {
+    it('should call pokeapi to get the detail for the list of pokemons', () => {
+      service.getPokemons(0).subscribe(value => {
+        expect(value).toBe([
+          { name: 'bulba' } as Pokemon,
+          { name: 'ivy' } as Pokemon,
+        ]);
+      });
+
+      const mainRequest = controller.expectOne(
+        'https://pokeapi.co/api/v2/pokemon?limit=20&offset=0'
+      );
+      // Answer the request so the Observable emits a value.
+      mainRequest.flush({
+        count: 2,
+        results: [
+          { url: 'url-1' } as PokemonLink,
+          { url: 'url-2' } as PokemonLink,
+        ],
+      });
+
+      const secondRequest = controller.expectOne('url-1');
+      // Answer the request so the Observable emits a value.
+      secondRequest.flush({ name: 'bulba' } as Pokemon);
+
+      const thirdRequest = controller.expectOne('url-2');
+      // Answer the request so the Observable emits a value.
+      thirdRequest.flush({ name: 'ivy' } as Pokemon);
+    });
+  });
+});

--- a/src/app/services/pokemon.service.ts
+++ b/src/app/services/pokemon.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { forkJoin, Observable, switchMap } from 'rxjs';
+
+import { PaginatedAnswer, Pokemon, PokemonLink } from '../definitions/pokemon';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PokemonService {
+  constructor(private readonly http: HttpClient) {}
+
+  getPokemons(page: number): Observable<Pokemon[]> {
+    return this.http
+      .get<PaginatedAnswer<PokemonLink>>(
+        `https://pokeapi.co/api/v2/pokemon?limit=20&offset=${page * 20}`
+      )
+      .pipe(
+        switchMap(({ results }) => {
+          return forkJoin(results.map(pokemon => this.getPokemon(pokemon.url)));
+        })
+      );
+  }
+
+  private getPokemon(url: string): Observable<Pokemon> {
+    return this.http.get<Pokemon>(url);
+  }
+}

--- a/src/app/store/pokemon-store/actions.ts
+++ b/src/app/store/pokemon-store/actions.ts
@@ -1,0 +1,23 @@
+import { createAction, props } from '@ngrx/store';
+import { type Pokemon } from '../../definitions/pokemon';
+
+export enum ActionTypes {
+  REQUEST_LOADING = 'Pokemon request loading',
+  REQUEST_FAILURE = 'Pokemon request failure',
+  REQUEST_SUCCESS = 'Pokemon request success',
+}
+
+export const loadRequest = createAction(
+  ActionTypes.REQUEST_LOADING,
+  props<{ page: number }>()
+);
+
+export const failRequest = createAction(
+  ActionTypes.REQUEST_FAILURE,
+  props<{ error: string }>()
+);
+
+export const successRequest = createAction(
+  ActionTypes.REQUEST_SUCCESS,
+  props<{ pokemons: Pokemon[] }>()
+);

--- a/src/app/store/pokemon-store/effects.ts
+++ b/src/app/store/pokemon-store/effects.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { catchError, exhaustMap, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { PokemonService } from '../../services/pokemon.service';
+import { ActionTypes, failRequest, successRequest } from './actions';
+
+@Injectable()
+export class PokemonEffects {
+  constructor(
+    private readonly actions: Actions,
+    private readonly pokemonService: PokemonService
+  ) {}
+
+  loadPokemons = createEffect(() => {
+    return this.actions.pipe(
+      ofType(ActionTypes.REQUEST_LOADING),
+      exhaustMap(({ page }) =>
+        this.pokemonService.getPokemons(page).pipe(
+          map(response => successRequest({ pokemons: response })),
+          catchError((error: { message: string }) =>
+            of(failRequest({ error: error.message }))
+          )
+        )
+      )
+    );
+  });
+}

--- a/src/app/store/pokemon-store/pokemonState.ts
+++ b/src/app/store/pokemon-store/pokemonState.ts
@@ -1,0 +1,15 @@
+import { Pokemon } from '../../definitions/pokemon';
+
+export interface PokemonState {
+  lastLoadedPageIndex: number | null;
+  items: Pokemon[];
+  error: string | null;
+  isLoading: boolean;
+}
+
+export const initialPokemonState: PokemonState = {
+  lastLoadedPageIndex: null,
+  items: [],
+  error: null,
+  isLoading: false,
+};

--- a/src/app/store/pokemon-store/reducer.ts
+++ b/src/app/store/pokemon-store/reducer.ts
@@ -1,0 +1,22 @@
+import { createReducer, on } from '@ngrx/store';
+import { failRequest, loadRequest, successRequest } from './actions';
+import { initialPokemonState, PokemonState } from './pokemonState';
+
+export const pokemonReducer = createReducer(
+  initialPokemonState,
+  on(loadRequest, (state): PokemonState => ({ ...state, isLoading: true })),
+  on(
+    failRequest,
+    (state, { error }): PokemonState => ({ ...state, isLoading: false, error })
+  ),
+  on(
+    successRequest,
+    (state, { pokemons }): PokemonState => ({
+      ...state,
+      items: [...state.items, ...pokemons],
+      isLoading: false,
+      lastLoadedPageIndex:
+        state.lastLoadedPageIndex !== null ? state.lastLoadedPageIndex + 1 : 0,
+    })
+  )
+);

--- a/src/app/store/pokemon-store/selector.ts
+++ b/src/app/store/pokemon-store/selector.ts
@@ -1,0 +1,19 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { PokemonState } from './pokemonState';
+
+const selectPokemonFeature = createFeatureSelector<PokemonState>('pokemons');
+
+export const selectPokemons = createSelector(
+  selectPokemonFeature,
+  (state: PokemonState) => state.items
+);
+
+export const selectLoadingState = createSelector(
+  selectPokemonFeature,
+  (state: PokemonState) => state.isLoading
+);
+
+export const selectError = createSelector(
+  selectPokemonFeature,
+  (state: PokemonState) => state.error
+);

--- a/src/app/store/state.ts
+++ b/src/app/store/state.ts
@@ -1,0 +1,5 @@
+import { PokemonState } from './pokemon-store/pokemonState';
+
+export interface AppState {
+  pokemons: PokemonState;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>TestPokemonApi</title>
+    <title>Test pokemon api</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
   <body>
-    <app-root></app-root>
+    <pkm-root></pkm-root>
   </body>
 </html>

--- a/src/styles.sass
+++ b/src/styles.sass
@@ -1,1 +1,4 @@
 /* You can add global styles to this file, and also import other style files */
+body
+  margin: 0
+  fonct: arial


### PR DESCRIPTION
implement the basic behavior for the page listing pokemons.

Includes: 
* store (effects, actions, reducers and selectors) to handle properly the pokemons state properly
* basic implementation on the page (display the first 20 elements for now)
* Most of the testing has been done, only the store part has yet to be tested
